### PR TITLE
Add support for HTTP headers

### DIFF
--- a/dyndns
+++ b/dyndns
@@ -203,7 +203,7 @@ class URL:
             response_l.append(response)
         elif isinstance(response, list):
             response_l.extend(response)
-        else:
+        elif response is not None:
             sys.exit(f'ERROR: url {self.url}, response must be string or list.')
 
         self.response = [re.compile(s) for s in response_l]

--- a/dyndns
+++ b/dyndns
@@ -72,10 +72,12 @@ def logerr(msg: str) -> None:
     print(msg, file=sys.stderr, flush=True)
 
 
-async def urlget(session: Session, url: str) -> str | None:
+async def urlget(
+    session: Session, url: str, headers: dict[str, str] | None = None
+) -> str | None:
     "Fetch given url"
     try:
-        async with session.get(url) as response:
+        async with session.get(url, headers=headers) as response:
             response.raise_for_status()
             txt = await response.text()
     except Exception as e:
@@ -171,6 +173,13 @@ class URL:
         if not self.url:
             sys.exit('ERROR: url not defined')
             return
+        headers = conf.get('headers')
+        if isinstance(headers, dict):
+            self.request_headers: dict[str, str] = headers
+        elif headers is not None:
+            sys.exit(f'ERROR: url {self.url}, headers must be a dictionary.')
+        else:
+            self.request_headers = {}
 
         # Record which IP address types we need for this URL
         self.needs = {k for k in ADDRESS_TYPES if self.url and f'<{k}>' in self.url}
@@ -268,7 +277,7 @@ class URL:
             self.session = Session()
 
         # Send to dyndns server
-        response = await urlget(self.session, url)
+        response = await urlget(self.session, url, self.request_headers)
         if response is not None:
             if not self.response or any(s.search(response) for s in self.response):
                 # Update successful, save new record to cache file

--- a/dyndns.toml
+++ b/dyndns.toml
@@ -10,7 +10,7 @@
 #
 # A [[urls]] entry can have the following values:
 #
-# url (mandatory): The URL of the service. Typically have to add your
+# url (mandatory): The URL of the service. Typically you have to add your
 #   DOMAIN or HOSTNAME and/or your TOKEN or PASSWORD as parameters in
 #   this URL. You can add the placemarkers "<ipv4>" and/or "<ipv6>"
 #   where you want those IP addresses inserted when sent to the service.
@@ -28,6 +28,10 @@
 #   returned). Can be a single string, or a list of regular expression
 #   strings. If any comparison of a string in that list passes, then the
 #   URL message is considered successful. See the examples below.
+#
+# [headers] (optional): This is a dictionary used to pass arbitrary
+#   headers to the HTTP requests used to update the dyndns server.
+#   This can be used to e.g. authenticate with the server.
 #
 # Some example [[urls]] entries follow:
 
@@ -59,6 +63,13 @@
 # [[urls]]
 # url = 'https://www.duckdns.org/update?domains=HOSTNAME&token=TOKEN&ip=<ipv4>&ipv6=<ipv6>'
 # response = '^OK$'
+
+# desec.io: See https://desec.readthedocs.io/en/latest/dyndns/update-api.html.
+# [[urls]]
+# url = "https://update.dedyn.io/?hostname=HOSTNAME&myipv4=<ipv4>&myipv6=<ipv6>"
+# response = "good"
+# [urls.headers]
+# Authorization = "Token TOKEN"
 
 # *** SHOULD NOT NEED TO MODIFY ANY OF THE FOLLOWING SETTINGS ***
 #


### PR DESCRIPTION
Authentication via query parameters is often times not recommended, as it can leak your authentication method (e.g. URL logging on the server side, etc.).
Thus, authentication via HTTP header is recommended.
Add support to pass these headers to the URL configuration.